### PR TITLE
Début persistance DB et cycles

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,8 @@
 
 Cette liste reprend les actions nécessaires pour rendre l'application pleinement opérationnelle.
 
-- [ ] **Persistance des données** : remplacer l'actuelle base en mémoire par une véritable base (ex. Postgres via Prisma). Adapter `packages/api` et prévoir les migrations.
-- [ ] **Gestion complète des cycles d'entraînement** : structurer macrocycles, mésocycles et microcycles et automatiser la montée de charge (4 semaines + 1 semaine allégée).
+- [ ] **Persistance des données** *(en cours)* : remplacer l'actuelle base en mémoire par une véritable base (ex. Postgres via Prisma). Adapter `packages/api` et prévoir les migrations.
+- [ ] **Gestion complète des cycles d'entraînement** *(en cours)* : structurer macrocycles, mésocycles et microcycles et automatiser la montée de charge (4 semaines + 1 semaine allégée).
 - [ ] **Ajustement dynamique selon l'ACWR** : adapter automatiquement la durée ou l'intensité des séances lorsque le ratio dépasse les seuils.
 - [ ] **Module nutrition avancé** : calculer les apports en glucides, protéines, lipides et suivre l'hydratation.
 - [ ] **Prise en charge des blessures** : enregistrer les blessures, appliquer la méthode RICE puis programmer la reprise progressive.

--- a/packages/api/app/cycles.py
+++ b/packages/api/app/cycles.py
@@ -7,7 +7,8 @@ sur quatre semaines suivies d'une semaine allégée.
 Ce fichier prépare l'implémentation du point 2 de TODO.md.
 """
 
-from dataclasses import dataclass, field
+from pydantic.dataclasses import dataclass
+from dataclasses import field
 from datetime import date, timedelta
 from typing import List
 

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -1,0 +1,8 @@
+import os
+
+if os.getenv("USE_PRISMA"):
+    from .prisma_db import PrismaDB
+    DB = PrismaDB()
+else:
+    from .db import InMemoryDB
+    DB = InMemoryDB()

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -6,9 +6,10 @@ from .acwr import compute_acwr
 from .rule_engine import adjust_sessions
 from .stats import stats_summary
 from .nutrition import calculate_plan, NutritionPlanRequest
+from .cycles import generate_macrocycle, Macrocycle
 
 from .models import TrainingSession, NutritionEntry, Injury, Competition
-from .db import DB
+from .database import DB
 
 app = FastAPI(title="Coaching App")
 
@@ -111,3 +112,9 @@ def get_stats_summary():
 def get_nutrition_plan(req: NutritionPlanRequest):
     """Return a basic nutrition plan from body weight and goal."""
     return calculate_plan(req.body_weight_kg, req.goal)
+
+
+@app.get("/cycles", response_model=Macrocycle)
+def create_macrocycle(start: date, weeks: int = 20):
+    """Generate a basic macrocycle starting at given date."""
+    return generate_macrocycle(start, weeks)

--- a/packages/api/app/prisma_db.py
+++ b/packages/api/app/prisma_db.py
@@ -1,0 +1,91 @@
+"""Implémentation initiale d'une base PostgreSQL via Prisma."""
+
+import asyncio
+from typing import List
+
+from prisma import Prisma
+from .models import TrainingSession
+
+
+class PrismaDB:
+    """Client Prisma simplifié pour stocker les séances."""
+
+    def __init__(self) -> None:
+        self.client = Prisma()
+        self._connected = False
+
+    async def connect(self) -> None:
+        if not self._connected:
+            await self.client.connect()
+            self._connected = True
+
+    async def disconnect(self) -> None:
+        if self._connected:
+            await self.client.disconnect()
+            self._connected = False
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def add_session(self, session: TrainingSession) -> TrainingSession:
+        async def _create():
+            record = await self.client.session.create(
+                data={
+                    "date": session.date,
+                    "sport": session.sport,
+                    "durationMin": session.duration_min,
+                    "rpe": session.rpe or 0,
+                }
+            )
+            session.id = record.id
+            return session
+
+        return self._run(_create())
+
+    def list_sessions(self) -> List[TrainingSession]:
+        async def _list():
+            records = await self.client.session.find_many(order={"id": "asc"})
+            return [
+                TrainingSession(
+                    id=r.id,
+                    date=r.date,
+                    sport=r.sport,
+                    duration_min=r.durationMin,
+                    rpe=r.rpe,
+                )
+                for r in records
+            ]
+
+        return self._run(_list())
+
+    def get_session(self, session_id: int) -> TrainingSession:
+        async def _get():
+            r = await self.client.session.find_unique(where={"id": session_id})
+            if not r:
+                return None
+            return TrainingSession(
+                id=r.id,
+                date=r.date,
+                sport=r.sport,
+                duration_min=r.durationMin,
+                rpe=r.rpe,
+            )
+
+        return self._run(_get())
+
+    def update_session(self, session_id: int, session: TrainingSession) -> TrainingSession:
+        async def _update():
+            await self.client.session.update(
+                where={"id": session_id},
+                data={
+                    "date": session.date,
+                    "sport": session.sport,
+                    "durationMin": session.duration_min,
+                    "rpe": session.rpe or 0,
+                },
+            )
+            return session
+
+        return self._run(_update())
+
+    # Les autres méthodes (nutrition, blessures, etc.) restent à implémenter

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -1,7 +1,7 @@
 // Prisma schema
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 generator client {


### PR DESCRIPTION
## Notes
- démarrage de la persistance PostgreSQL via Prisma
- début d'API pour générer un macrocycle
- marquage des tâches correspondantes dans `TODO.md`

## Summary
- bascule possible vers Prisma grâce au module `database`
- squelette de `PrismaDB` pour stocker les séances
- support des dataclasses Pydantic pour les cycles
- ajout d'une route `/cycles`

## Testing
- `pytest -q`