### PR TITLE
Implémentation persistance SQLite et planification cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ La structure principale est la suivante :
 - `GET /stats/summary` : ACWR, charges hebdo et progression.
 - `POST /nutrition/plan` : génère un plan nutrition basé sur le poids et l'objectif.
 - Les modèles sont définis dans `packages/api/app/models.py` et les données sont
-  stockées dans une base en mémoire (`packages/api/app/db.py`).
+  désormais persistées dans SQLite (`coaching.db`). On peut choisir un autre
+  backend via la variable d'environnement `COACHING_DB`.
 
 ## Frontend
 - React (structure minimaliste)

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,8 @@
 
 Cette liste reprend les actions nécessaires pour rendre l'application pleinement opérationnelle.
 
-- [ ] **Persistance des données** *(en cours - SQLite ajouté)* : remplacer l'actuelle base en mémoire par une véritable base (ex. Postgres via Prisma). Adapter `packages/api` et prévoir les migrations.
-- [ ] **Gestion complète des cycles d'entraînement** *(en cours - progression automatisée)* : structurer macrocycles, mésocycles et microcycles et automatiser la montée de charge (4 semaines + 1 semaine allégée).
+- [x] **Persistance des données** *(en cours - SQLite ajouté)* : remplacer l'actuelle base en mémoire par une véritable base (ex. Postgres via Prisma). Adapter `packages/api` et prévoir les migrations.
+- [x] **Gestion complète des cycles d'entraînement** *(en cours - progression automatisée)* : structurer macrocycles, mésocycles et microcycles et automatiser la montée de charge (4 semaines + 1 semaine allégée).
 - [ ] **Ajustement dynamique selon l'ACWR** *(en cours)* : adapter automatiquement la durée ou l'intensité des séances lorsque le ratio dépasse les seuils.
 - [ ] **Module nutrition avancé** *(en cours)* : calculer les apports en glucides, protéines, lipides et suivre l'hydratation.
 - [ ] **Prise en charge des blessures** *(en cours)* : enregistrer les blessures, appliquer la méthode RICE puis programmer la reprise progressive.

--- a/packages/api/app/cycles.py
+++ b/packages/api/app/cycles.py
@@ -7,10 +7,10 @@ sur quatre semaines suivies d'une semaine allégée.
 Ce fichier prépare l'implémentation du point 2 de TODO.md.
 """
 
-from pydantic.dataclasses import dataclass
-from dataclasses import field
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import List
+from .models import TrainingSession
 
 
 @dataclass
@@ -53,3 +53,34 @@ def generate_macrocycle(start: date, weeks: int) -> Macrocycle:
         macro.mesocycles.append(meso)
         current += timedelta(weeks=5)
     return macro
+
+
+def plan_sessions(
+    macro: Macrocycle,
+    base: TrainingSession,
+    sessions_per_week: int = 3,
+) -> List[TrainingSession]:
+    """Génère un ensemble de séances à partir d'un macrocycle.
+
+    Chaque microcycle applique son ``load_factor`` pour ajuster la durée de la
+    séance de base. Les séances sont espacées de deux jours.
+    """
+
+    planned: List[TrainingSession] = []
+    sid = 1
+    for meso in macro.mesocycles:
+        for mc in meso.microcycles:
+            for i in range(sessions_per_week):
+                session_date = mc.start + timedelta(days=i * 2)
+                sess = TrainingSession(
+                    id=sid,
+                    date=session_date,
+                    sport=base.sport,
+                    description=base.description,
+                    duration_min=int(base.duration_min * mc.load_factor),
+                    rpe=base.rpe,
+                )
+                planned.append(sess)
+                mc.sessions.append(sid)
+                sid += 1
+    return planned

--- a/tests/test_cycles.py
+++ b/tests/test_cycles.py
@@ -4,10 +4,19 @@ from datetime import date
 
 sys.path.append(os.path.abspath("packages/api"))
 
-from app.cycles import generate_macrocycle
+from app.cycles import generate_macrocycle, plan_sessions
+from app.models import TrainingSession
 
 
 def test_macrocycle_load_factors():
     macro = generate_macrocycle(date(2025, 1, 1), weeks=5)
     factors = [mc.load_factor for mc in macro.mesocycles[0].microcycles]
     assert factors == [1.0, 1.1, 1.2, 1.3, 0.8]
+
+
+def test_plan_sessions_uses_load_factor():
+    macro = generate_macrocycle(date(2025, 1, 1), weeks=5)
+    template = TrainingSession(id=0, date=date(2025, 1, 1), sport="run", duration_min=60, rpe=5)
+    sessions = plan_sessions(macro, template, sessions_per_week=1)
+    durations = [s.duration_min for s in sessions[:5]]
+    assert durations == [60, 66, 72, 78, 48]

--- a/tests/test_sqlite_db.py
+++ b/tests/test_sqlite_db.py
@@ -5,7 +5,7 @@ from datetime import date
 sys.path.append(os.path.abspath("packages/api"))
 
 from app.sqlite_db import SQLiteDB
-from app.models import TrainingSession
+from app.models import TrainingSession, NutritionEntry, Injury, Competition
 
 
 def make_session() -> TrainingSession:
@@ -27,3 +27,35 @@ def test_sqlite_reorder():
     s2 = db.add_session(make_session())
     ordered = db.reorder_sessions([s2.id, s1.id])
     assert [s.id for s in ordered] == [s2.id, s1.id]
+
+
+def test_sqlite_persist_file(tmp_path):
+    path = tmp_path / "test.db"
+    db = SQLiteDB(path=str(path))
+    db.add_session(make_session())
+    db.conn.close()
+    new_db = SQLiteDB(path=str(path))
+    assert len(new_db.list_sessions()) == 1
+
+
+def test_sqlite_other_tables():
+    db = SQLiteDB(path=":memory:")
+    n = db.add_nutrition(
+        NutritionEntry(
+            id=0,
+            date=date.today(),
+            calories=2000,
+            hydration_l=2.0,
+            carbs_g=250,
+            protein_g=100,
+            fat_g=70,
+        )
+    )
+    assert n.id > 0
+    assert len(db.list_nutrition()) == 1
+    injury = db.add_injury(Injury(id=0, start_date=date.today()))
+    assert injury.id > 0
+    assert len(db.list_injuries()) == 1
+    comp = db.add_competition(Competition(id=0, date=date.today(), name="10k"))
+    assert comp.id > 0
+    assert len(db.list_competitions()) == 1


### PR DESCRIPTION
## Notes
- Ajout d'une base SQLite complète et sélection du backend via `COACHING_DB`.
- Génération de séances à partir du macrocycle avec `plan_sessions`.
- Mise à jour des tests pour couvrir ces fonctionnalités.
- Mise à jour de `TODO.md` et `README.md`.

## Testing
- `pytest -q`