### PR TITLE
Ajout onglet Statistiques

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
   }
 }

--- a/apps/web/src/index.js
+++ b/apps/web/src/index.js
@@ -8,6 +8,8 @@ import {
 } from 'react-router-dom';
 
 import { API_URL } from './api';
+import { Line } from 'react-chartjs-2';
+import 'chart.js/auto';
 
 function Dashboard() {
   const [todaySessions, setTodaySessions] = useState([]);
@@ -176,6 +178,38 @@ function Progress() {
   );
 }
 
+function Stats() {
+  const [summary, setSummary] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/stats/summary`).then((res) => res.json()).then(setSummary);
+  }, []);
+
+  if (!summary) return <p>Chargement...</p>;
+
+  const data = {
+    labels: ['Semaine -3', 'Semaine -2', 'Semaine -1', 'Semaine'],
+    datasets: [
+      {
+        label: 'Charge',
+        data: summary.weekly_loads,
+        backgroundColor: 'rgba(75,192,192,0.4)',
+        borderColor: 'rgba(75,192,192,1)',
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h1>Statistiques</h1>
+      <Line data={data} />
+      <p>ACWR : {summary.acwr.toFixed(2)}</p>
+      <p>Progression : {summary.progression.toFixed(1)}%</p>
+    </div>
+  );
+}
+
 function Competitions() {
   const [comps, setComps] = useState([]);
   const [date, setDate] = useState('');
@@ -227,7 +261,8 @@ function App() {
         <Link to="/add-nutrition">Nutrition</Link> |{' '}
         <Link to="/add-injury">Blessure</Link> |{' '}
         <Link to="/competitions">Compétitions</Link> |{' '}
-        <Link to="/progress">Progression</Link>
+        <Link to="/progress">Progression</Link> |{' '}
+        <Link to="/stats">Statistiques</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
@@ -237,6 +272,7 @@ function App() {
         <Route path="/add-injury" element={<AddInjury />} />
         <Route path="/competitions" element={<Competitions />} />
         <Route path="/progress" element={<Progress />} />
+        <Route path="/stats" element={<Stats />} />
       </Routes>
     </Router>
   );


### PR DESCRIPTION
## Notes
- Ajout d'un onglet Statistiques sur le frontend React.
- Intégration de Chart.js pour visualiser les charges hebdomadaires.

## Summary
- installation des dépendances `chart.js` et `react-chartjs-2` dans le package du front【F:apps/web/package.json†L8-L14】
- importation de `Line` de `react-chartjs-2` et création du composant `Stats` affichant un graphique et les indicateurs calculés【F:apps/web/src/index.js†L10-L12】【F:apps/web/src/index.js†L181-L210】
- ajout des liens et routes correspondants dans la navigation de l'application【F:apps/web/src/index.js†L260-L276】

## Testing
- `pytest -q`