### PR TITLE
Fix FastAPI startup by enhancing pydantic stub

### DIFF
--- a/packages/api/pydantic/__init__.py
+++ b/packages/api/pydantic/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict, Tuple, Type
 
 class BaseModel:
     def __init__(self, **data: Any):
@@ -15,3 +15,30 @@ class BaseModel:
 
 def Field(default: Any, **kwargs) -> Any:
     return default
+
+
+def create_model(name: str, **fields: Tuple[type, Any]) -> Type[BaseModel]:
+    """Create a simple Pydantic-like model.
+
+    Parameters
+    ----------
+    name: str
+        Name of the generated class.
+    fields: mapping of field names to a ``(type, default)`` tuple.
+
+    Returns
+    -------
+    Type[BaseModel]
+        Newly created model class inheriting from ``BaseModel``.
+    """
+    annotations: Dict[str, type] = {}
+    namespace: Dict[str, Any] = {}
+    for field_name, value in fields.items():
+        if isinstance(value, tuple) and len(value) == 2:
+            field_type, default = value
+        else:
+            field_type, default = value, None
+        annotations[field_name] = field_type
+        namespace[field_name] = default
+    namespace["__annotations__"] = annotations
+    return type(name, (BaseModel,), namespace)


### PR DESCRIPTION
## Summary
- add a minimal `create_model` implementation to the local pydantic stub

## Testing
- `pytest -q`