### PR TITLE
Fix pydantic exports and add root start script

### DIFF
--- a/packages/api/pydantic/__init__.py
+++ b/packages/api/pydantic/__init__.py
@@ -2,7 +2,20 @@
 
 from typing import Any, Dict, Tuple, Type
 
+# Expose VERSION constant used by FastAPI for compatibility checks
 from .version import VERSION
+
+__all__ = [
+    "BaseModel",
+    "BaseSettings",
+    "BaseConfig",
+    "Field",
+    "create_model",
+    "AnyUrl",
+    "HttpUrl",
+    "AnyHttpUrl",
+    "VERSION",
+]
 
 class BaseModel:
     def __init__(self, **data: Any):
@@ -17,10 +30,16 @@ class BaseModel:
         return self.__dict__
 
 
-class BaseSettings(BaseModel):
-    """Placeholder de ``BaseSettings`` compatible avec Pydantic."""
+class BaseConfig:
+    """Minimal configuration container used by FastAPI."""
 
     pass
+
+
+class BaseSettings(BaseModel):
+    """Stub of Pydantic's BaseSettings."""
+
+    Config = BaseConfig
 
 
 class AnyUrl(str):

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Wrapper to launch the API from the repository root
+set -e
+cd "$(dirname "$0")/packages/api"
+exec ./start.sh "$@"


### PR DESCRIPTION
## Summary
- expose VERSION constant and related exports in the pydantic stub
- provide a minimal BaseConfig and Config for BaseSettings
- add a helper `start.sh` at repo root to run the API start script

## Testing
- `pytest -q`