### PR TITLE
Fix server startup path

### DIFF
--- a/packages/api/start.sh
+++ b/packages/api/start.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 # Installation des dépendances et lancement du serveur
 set -e
-pip install -r requirements.txt
-exec uvicorn app.main:app --reload
+
+SCRIPT_DIR="$(dirname "$0")"
+pip install -r "$SCRIPT_DIR/requirements.txt"
+
+# Lancer Uvicorn depuis la racine du repo pour ne pas surcharger Pydantic
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+exec uvicorn packages.api.app.main:app --reload


### PR DESCRIPTION
## Summary
- fix Pydantic shadowing when starting the API by launching Uvicorn from repo root

## Testing
- `pytest`
