### PR TITLE
Ajout redirection racine vers la documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+coaching.db
+__pycache__/
+packages/api/app/__pycache__/
+packages/api/pydantic/__pycache__/
+tests/__pycache__/
+*.pyc
+

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
 from typing import List, Optional
 from datetime import date, timedelta
 
@@ -12,6 +13,12 @@ from .models import TrainingSession, NutritionEntry, Injury, Competition
 from .database import DB
 
 app = FastAPI(title="Coaching App")
+
+
+@app.get("/", include_in_schema=False)
+def root_redirect():
+    """Redirect to the interactive API documentation."""
+    return RedirectResponse(url="/docs")
 
 @app.get("/health")
 def health_check():

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath('packages/api'))
+
+main = pytest.importorskip('app.main', reason='fastapi not available')
+pytest.importorskip('fastapi')
+from app.db import InMemoryDB
+from fastapi.testclient import TestClient
+
+
+def get_client() -> TestClient:
+    main.DB = InMemoryDB()
+    return TestClient(main.app)
+
+
+def test_root_redirect():
+    client = get_client()
+    resp = client.get('/', allow_redirects=False)
+    assert resp.status_code in (302, 307)
+    assert resp.headers['location'] == '/docs'


### PR DESCRIPTION
## Notes
- Ajout d'une route `/` dans l'API FastAPI qui redirige vers `/docs`
- Création d'un test `test_root.py` vérifiant cette redirection
- Ajout d'un `.gitignore` pour ignorer les caches Python et la base sqlite

## Résultats des tests
```
pytest -q
```
