### PR TITLE
Start API and web together

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ La structure principale est la suivante :
 ## Démarrage rapide
 
 ```bash
-cd packages/api
 ./start.sh
 ```
+
+Le script démarre l'API et l'interface web. Le frontend est ensuite
+accessible sur `http://localhost:3000`.
 
 La liste complète des endpoints est présentée dans [docs/api.md](docs/api.md).
 

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,22 @@
 #!/bin/sh
-# Wrapper to launch the API from the repository root
+# Lance à la fois le backend FastAPI et le frontend React
 set -e
-cd "$(dirname "$0")/packages/api"
-exec ./start.sh "$@"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+start_backend() {
+    (cd "$SCRIPT_DIR/packages/api" && ./start.sh "$@")
+}
+
+start_frontend() {
+    (cd "$SCRIPT_DIR/apps/web" && npm install && npm start)
+}
+
+start_backend &
+BACKEND_PID=$!
+
+start_frontend &
+FRONTEND_PID=$!
+
+trap 'kill $BACKEND_PID $FRONTEND_PID 2>/dev/null' INT TERM EXIT
+wait $BACKEND_PID $FRONTEND_PID


### PR DESCRIPTION
## Summary
- run backend and frontend concurrently via `start.sh`
- update quick start instructions

## Testing
- `pytest -q`
