### PR TITLE
Fix serving path and improve front messages

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@ import os
 import secrets
 from datetime import datetime
 from fastapi import FastAPI, HTTPException, Depends
+from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from sqlmodel import Session, select
@@ -83,4 +84,9 @@ def delete_session(session_id: int, _: HTTPBasicCredentials = Depends(require_au
     return {"status": "deleted"}
 
 
-app.mount("/", StaticFiles(directory="static", html=True), name="static")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.get("/", response_class=HTMLResponse)
+def root() -> FileResponse:
+    return FileResponse("static/index.html")

--- a/static/index.html
+++ b/static/index.html
@@ -912,7 +912,9 @@ document.getElementById('sessionForm').addEventListener('submit', async e => {
     duration: +document.getElementById('duration').value,
     rpe: +document.getElementById('rpe').value
   };
-  const resp = await fetch('/sessions', {method:'POST', headers:{'Content-Type':'application/json', ...getAuth()}, body: JSON.stringify(payload)});
+  const headers = getAuth();
+  headers['Content-Type'] = 'application/json';
+  const resp = await fetch('/sessions', {method:'POST', headers, body: JSON.stringify(payload)});
   if(resp.ok){
     document.getElementById('sessionForm').reset();
     document.getElementById('msg').textContent = '✅ Séance ajoutée';
@@ -938,6 +940,9 @@ async function loadSessions(){
       tbody.appendChild(tr);
     });
     table.classList.remove('hidden');
+    document.getElementById('msg').textContent = '✅ Liste chargée';
+  } else {
+    document.getElementById('msg').textContent = 'Erreur chargement séances';
   }
 }
 document.getElementById('sessionsTable').addEventListener('click', async e => {
@@ -946,6 +951,9 @@ document.getElementById('sessionsTable').addEventListener('click', async e => {
     const resp = await fetch(`/sessions/${id}`, {method:'DELETE', headers: getAuth()});
     if(resp.ok){
       loadSessions();
+      document.getElementById('msg').textContent = '✅ Séance supprimée';
+    } else {
+      document.getElementById('msg').textContent = 'Erreur suppression';
     }
   }
 });


### PR DESCRIPTION
## Summary
- expose static directory under `/static`
- add explicit `/` route serving index
- fix headers in fetch and show messages for list/delete

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*