### PR TITLE
Correctifs front et API

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,14 +19,14 @@ from src.sport_plan import (
 
 security = HTTPBasic()
 
+docs_setting = None if os.getenv("ENV") == "prod" else "/docs"
+app = FastAPI(docs_url=docs_setting)
+
 def require_auth(credentials: HTTPBasicCredentials = Depends(security)) -> None:
     pwd = os.getenv("APP_PASSWORD")
     valid = credentials.username == "admin" and pwd and secrets.compare_digest(credentials.password, pwd)
     if not valid:
         raise HTTPException(status_code=401, detail="Unauthorized")
-
-app = FastAPI()
-
 
 @app.on_event("startup")
 def on_startup() -> None:

--- a/static/index.html
+++ b/static/index.html
@@ -912,9 +912,11 @@ document.getElementById('sessionForm').addEventListener('submit', async e => {
     duration: +document.getElementById('duration').value,
     rpe: +document.getElementById('rpe').value
   };
-  const headers = getAuth();
-  headers['Content-Type'] = 'application/json';
-  const resp = await fetch('/sessions', {method:'POST', headers, body: JSON.stringify(payload)});
+  const resp = await fetch('/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...getAuth() },
+    body: JSON.stringify(payload)
+  });
   if(resp.ok){
     document.getElementById('sessionForm').reset();
     document.getElementById('msg').textContent = '✅ Séance ajoutée';
@@ -924,7 +926,7 @@ document.getElementById('sessionForm').addEventListener('submit', async e => {
   }
 });
 async function loadSessions(){
-  const resp = await fetch('/sessions', {headers: getAuth()});
+  const resp = await fetch('/sessions', {headers: { ...getAuth() }});
   if(resp.ok){
     const data = await resp.json();
     const table = document.getElementById('sessionsTable');
@@ -948,7 +950,10 @@ async function loadSessions(){
 document.getElementById('sessionsTable').addEventListener('click', async e => {
   if(e.target.classList.contains('delete-btn')){
     const id = e.target.dataset.id;
-    const resp = await fetch(`/sessions/${id}`, {method:'DELETE', headers: getAuth()});
+    const resp = await fetch(`/sessions/${id}`, {
+      method: 'DELETE',
+      headers: { ...getAuth() }
+    });
     if(resp.ok){
       loadSessions();
       document.getElementById('msg').textContent = '✅ Séance supprimée';

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,3 +55,8 @@ async def test_e2e(engine):
         assert r.status_code == 200
         data = r.json()
         assert len(data) == 1
+        sid = data[0]["id"]
+        r = await ac.delete(f"/sessions/{sid}", auth=auth)
+        assert r.status_code == 200
+        r = await ac.get("/sessions", auth=auth)
+        assert r.json() == []


### PR DESCRIPTION
## Notes
- Activation conditionnelle de la doc FastAPI selon `ENV`
- Fusion propre des en-têtes fetch côté front
- Test async enrichi pour vérifier la suppression

## Summary
- disable docs in prod via ENV check
- merge auth headers with content type in JS
- update async test to delete created session

## Testing
- `pytest -q` *(échoue: ModuleNotFoundError: No module named 'sqlmodel')*